### PR TITLE
Fixes for EC2 metadata credentials

### DIFF
--- a/lib/cloudinstancecredentials/ec2credentials.py
+++ b/lib/cloudinstancecredentials/ec2credentials.py
@@ -31,10 +31,9 @@ class Ec2InstanceMetadata(InstanceMetadata):
 
     # private methods
 
-    def _get_instance_identity_doc(self):
+    def _get_instance_metadata(self):
         """Retrive and cache the instance identity document (IID)"""
-        meta = ec2metadata.EC2Metadata()
-        meta.setAPIVersion('latest')
+        meta = ec2metadata.EC2Metadata(api='latest')
         return json.loads(meta.get('document'))
 
     def _get_instance_id(self):

--- a/lib/cloudinstancecredentials/frameworkfactory.py
+++ b/lib/cloudinstancecredentials/frameworkfactory.py
@@ -25,7 +25,7 @@ def get_metadata(logger):
     try:
         return azurecredentials.AzureInstanceMetadata(logger)
     except Exception:
-        return None
+        pass
     try:
         return ec2credentials.Ec2InstanceMetadata(logger)
     except Exception:


### PR DESCRIPTION
- right method name of InstanceMetadata
- no return if not Azure